### PR TITLE
Nissix plugin scope-packages on @wix/wix-renovate-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "puppeteer": "^1.1.0",
     "react-testing-library": "^6.0.2",
     "velocity": "~0.7.0",
-    "yoshi": "^4.1.0",
+    "@wix/yoshi": "^4.1.0",
     "yoshi-style-dependencies": "^4.1.0"
   },
   "dependencies": {
@@ -41,7 +41,7 @@
     "react-dom": "16.8.0",
     "react-i18next": "^7.11.0",
     "@wix/wix-axios-config": "latest",
-    "yoshi-template-intro": "^4.1.0"
+    "@wix/yoshi-template-intro": "^4.1.0"
   },
   "lint-staged": {
     "*.{js,scss,less}": "yoshi lint"

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -17,7 +17,7 @@ class App extends React.Component {
   /* <-- Please also remove `yoshi-template-intro` from your package.json */
   state = {};
   async componentDidMount() {
-    const { default: TemplateIntro } = await import('yoshi-template-intro');
+    const { default: TemplateIntro } = await import('@wix/yoshi-template-intro');
     this.setState({ TemplateIntro });
   } /* --> */
 

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,5 +1,5 @@
 module.exports = function(wallaby) {
-  return Object.assign({}, require('yoshi/config/wallaby-jest')(wallaby), {
+  return Object.assign({}, require('@wix/yoshi/config/wallaby-jest')(wallaby), {
     // set to undefined to let Wallaby decide the number of processes based on the system's capacity
     workers: undefined,
   });


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.107s



Output Log:
Migrating package "@wix/wix-renovate-app" in .


## Migration from non scope to @wix/scoped packages
> /tmp/b9d7cef6d311c357bd71b9be7bc3e28e

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
src/components/App/App.js
```

